### PR TITLE
Stop showing deprecation warning

### DIFF
--- a/libraries/resource_deploy.rb
+++ b/libraries/resource_deploy.rb
@@ -84,11 +84,9 @@ class Chef
         @checkout_branch = "deploy"
       end
 
-      # This resource is deprecated.
-      def after_created
-        Chef.deprecated(:deploy_resource, "The #{resource_name} resource (#{source_line}) is deprecated and will be removed from Chef core in 14.0 (April 2018). " \
-          "A migration cookbook will be available in the future, see the deprecation documentation for more information.")
-      end
+      # Hide the method defined in Chef::Resource bundled with Chef 13
+      # to prevent deprecation warning.
+      def after_created; end
 
       # where the checked out/cloned code goes
       def destination


### PR DESCRIPTION
### Description

There is no need to show warning about the depreaction of `deploy` resource when this cookbook is loaded.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
