### PR TITLE
Chef 16 fixes

### DIFF
--- a/libraries/resource_deploy.rb
+++ b/libraries/resource_deploy.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Daniel DeLeo (<dan@kallistec.com>)
 # Author:: Tyler Cloke (<tyler@chef.io>)
-# Copyright:: Copyright 2008-2016, Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,8 +36,6 @@
 #   svn_password "supersecret"
 # end
 
-require 'chef/resource/scm'
-
 class Chef
   class Resource
     # Deploy: Deploy apps from a source control repository.
@@ -50,6 +48,8 @@ class Chef
     # release directory. Callback files can contain chef code (resources, etc.)
     #
     class Deploy < Chef::Resource
+      provides :deploy
+
       identity_attr :repository
 
       state_attrs :deploy_to, :revision

--- a/libraries/resource_deploy_revision.rb
+++ b/libraries/resource_deploy_revision.rb
@@ -21,9 +21,11 @@ class Chef
     # Convenience class for using the deploy resource with the revision
     # deployment strategy (provider)
     class DeployRevision < Chef::Resource::Deploy
+      provides :deploy_revision
     end
 
     class DeployBranch < Chef::Resource::DeployRevision
+      provides :deploy_branch
     end
   end
 end


### PR DESCRIPTION
The require line here was never necessary.  Someone who knew java
at some point probably though you needed it, but due to duck typing
it doesn't matter.  All that matters is the symbols that are referenced.

The only symbol that was referenced was Chef::Provider::Git.
Theoretically it should require that, but it can rely on chef-client to
have required that via the `resources.rb` file.

The other fix is that the magical DSL wiring via the class name for
library based resources+providers has been removed in Chef-16, so had to
add that.

What is curious there is that the timestamped provider is declaring a
`provides :deploy` while the actual Chef::Provider::Deploy class is
getting the magical wiring to `provides :deploy` on the DSL.  I think
that this preserves backwards compatibility but I wouldn't bet my life
on it.  The alphanumeric sort order of the library loading code should
mean that the provider_deploy.rb file is loaded first, and that class is
wired up to the `deploy` DSL magically, then the provider_timestamped.rb
is loaded and that class is wired up to the `deploy` DSL explicitly, and
that seems to be the clear intent of the author.  In Chef-16 that
magical wiring is gone, but the behavior should be backcompatible due to
the sort order of the library resource loading.

And that paragraph largely explains why both of these changes need to be
made.  If you don't understand, offhand, what is going on there without
needing to be reminded of it and/or are still confused about that
paragraph, the point is to remove all the complexity.  Going forwards in
Chef-16 there is no magical class-name based load ordering to worry
about.  It becomes a thing nobody needs to care about.  Similarly
abstract base classes like Chef::Provider::Deploy here or the
Chef::Resource::Scm provider in core chef need to be removed and
replaced with partials, both to convert resources to custom resources
and to be clear that there is not a class there which can be
instantiated usefully.  This is also part of the march towards custom
resources everywhere and eliminating library resources+provides like
this one (which is why this one broke in Chef-16).

And the biggest reason why is that I'm the only person on the planet
that understands this stuff offhand and I don't scale and I can't be
called in as an airstrike on every situation that arises.  These changes
are necessary to remove all the sharp edges from using chef-client.
